### PR TITLE
Adds a low-level-api example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+# ENSIME specific
+.ensime_cache/
+.ensime
+
+# IDEA Specific
+.idea/
+*.iws
+/out/
+.idea_modules/
+
+.DS_Store
+
+/secring.gpg

--- a/low-level-api/.scalafmt.conf
+++ b/low-level-api/.scalafmt.conf
@@ -1,0 +1,22 @@
+style = defaultWithAlign
+maxColumn = 100
+
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+docstrings = JavaDoc
+
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.maxLines = 1
+}

--- a/low-level-api/build.sbt
+++ b/low-level-api/build.sbt
@@ -1,0 +1,14 @@
+name := "freestyle-cassandra-low-level-api"
+
+scalaVersion := "2.12.2"
+
+resolvers += Resolver.sonatypeRepo("snapshots")
+
+libraryDependencies ++= Seq(
+    "io.frees" %% "freestyle-monix" % "0.3.0",
+    "io.frees" %% "freestyle-async-monix" % "0.3.0",
+    "io.frees" %% "freestyle-cassandra-core" % "0.0.1-SNAPSHOT",
+    "io.frees" %% "freestyle-cassandra-macros" % "0.0.1-SNAPSHOT"
+  )
+
+addCompilerPlugin("org.scalameta" % "paradise" % "3.0.0-M8" cross CrossVersion.full)

--- a/low-level-api/build.sbt
+++ b/low-level-api/build.sbt
@@ -5,10 +5,10 @@ scalaVersion := "2.12.2"
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
-    "io.frees" %% "freestyle-monix" % "0.3.0",
-    "io.frees" %% "freestyle-async-monix" % "0.3.0",
+    "io.frees" %% "freestyle-monix" % "0.2.0",
+    "io.frees" %% "freestyle-async-monix" % "0.2.0",
     "io.frees" %% "freestyle-cassandra-core" % "0.0.1-SNAPSHOT",
     "io.frees" %% "freestyle-cassandra-macros" % "0.0.1-SNAPSHOT"
   )
 
-addCompilerPlugin("org.scalameta" % "paradise" % "3.0.0-M8" cross CrossVersion.full)
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/low-level-api/project/build.properties
+++ b/low-level-api/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/low-level-api/src/main/scala/freestyle/cassandra/sample/Implicits.scala
+++ b/low-level-api/src/main/scala/freestyle/cassandra/sample/Implicits.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra.sample
+
+import java.util.UUID
+
+import cats.~>
+import com.datastax.driver.core.{Cluster, ProtocolVersion, Session, TypeCodec}
+import freestyle.asyncMonix.implicits._
+import freestyle.cassandra.api.LowLevelAPI
+import monix.eval.{Task => MonixTask}
+
+
+object Implicits {
+
+  val cluster: Cluster = Cluster
+    .builder()
+    .addContactPoint("127.0.0.1")
+    .build()
+
+  lazy implicit val session: Session = cluster.connect("demodb")
+
+  implicit val stringTypeCodec: TypeCodec[String] = TypeCodec.varchar()
+
+  implicit val uuidTypeCodec: TypeCodec[UUID] = TypeCodec.uuid()
+
+  implicit val protocolVersion: ProtocolVersion = ProtocolVersion.V4
+
+  import freestyle.cassandra.implicits._
+
+  implicit val lowLevelAPIHandler: LowLevelAPI.Op ~> MonixTask = listenableFutureHandler andThen listenableFuture2Async[MonixTask]
+
+}

--- a/low-level-api/src/main/scala/freestyle/cassandra/sample/Model.scala
+++ b/low-level-api/src/main/scala/freestyle/cassandra/sample/Model.scala
@@ -16,11 +16,8 @@
 
 package freestyle.cassandra.sample
 
-import freestyle.cassandra.macros.table
-
 object Model {
 
-  @table
   case class User(id: java.util.UUID, name: String)
 
 }

--- a/low-level-api/src/main/scala/freestyle/cassandra/sample/Model.scala
+++ b/low-level-api/src/main/scala/freestyle/cassandra/sample/Model.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra.sample
+
+import freestyle.cassandra.macros.table
+
+object Model {
+
+  @table
+  case class User(id: java.util.UUID, name: String)
+
+}

--- a/low-level-api/src/main/scala/freestyle/cassandra/sample/Program.scala
+++ b/low-level-api/src/main/scala/freestyle/cassandra/sample/Program.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.cassandra.sample
+
+import java.util.UUID
+
+import cats.instances.future._
+import freestyle._
+import freestyle.async._
+import freestyle.async.implicits._
+import freestyle.asyncMonix.implicits._
+import freestyle.implicits._
+import freestyle.cassandra.codecs._
+import freestyle.cassandra.sample.Implicits._
+import freestyle.cassandra.sample.Model._
+import freestyle.cassandra.api.LowLevelAPI
+import monix.eval.{Task => MonixTask}
+import monix.cats._
+import monix.execution.Scheduler
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+
+object Program extends App {
+
+  implicit val executionContext: Scheduler = Scheduler.Implicits.global
+
+  def program[F[_]](implicit lowLevelAPI: LowLevelAPI[F]): FreeS[F, User] = {
+
+    val newUser = User(UUID.randomUUID(), "Username")
+
+    for {
+      _ <- lowLevelAPI.executeStatement(newUser.boundedInsert)
+      user <- lowLevelAPI.executeWithMap(
+        s"SELECT id, name FROM User WHERE id = ?",
+        Map("id" -> newUser.id)) map { rs =>
+        val row = rs.one()
+        User(row.getUUID(0), row.getString(1))
+      }
+      _ <- lowLevelAPI.close
+    } yield user
+  }
+
+  val task: MonixTask[Option[User]] = program[LowLevelAPI.Op]
+    .interpret[MonixTask]
+    .map(Option(_))
+    .onErrorRecover {
+      case NonFatal(t) =>
+        t.printStackTrace()
+        cluster.close()
+        None
+    }
+
+  val result: Option[User] = Await.result(task.runAsync, Duration.Inf)
+  println(result)
+
+  cluster.close()
+}

--- a/low-level-api/src/main/scala/freestyle/cassandra/sample/Program.scala
+++ b/low-level-api/src/main/scala/freestyle/cassandra/sample/Program.scala
@@ -20,11 +20,6 @@ import java.util.UUID
 
 import cats.instances.future._
 import freestyle._
-import freestyle.async._
-import freestyle.async.implicits._
-import freestyle.asyncMonix.implicits._
-import freestyle.implicits._
-import freestyle.cassandra.codecs._
 import freestyle.cassandra.sample.Implicits._
 import freestyle.cassandra.sample.Model._
 import freestyle.cassandra.api.LowLevelAPI


### PR DESCRIPTION
This PR brings a basic example of `freestyle-cassandra` low level API

By now, it shows how to use the [` LowLevelAPI`](https://github.com/frees-io/freestyle-cassandra/blob/23261be9cab85c5210c82e0aa8707d7b72912485/core/src/main/scala/freestyle/cassandra/api/LowLevelAPI.scala) for executing custom raw queries.

The `freestyle-cassandra` is a WIP and this example will be updated accordingly